### PR TITLE
Update parameter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Then you will need to get a quote:
 ### Getting Quote:
 ```javascript
 const quote = await fetchQuote({
-  amountIn: 250,
+  amount: 250,
   fromToken: fromToken.contract,
   toToken: toToken.contract,
   fromChain: "bsc",


### PR DESCRIPTION
As per https://github.com/mayan-finance/swap-sdk/blob/main/src/types.ts#L21 `QuoteParams` has field `amount` instead of `amountIn`. 