### PR TITLE
Solana: move sendRawTransaction into no signature case

### DIFF
--- a/src/solana/utils.ts
+++ b/src/solana/utils.ts
@@ -69,8 +69,8 @@ export async function submitTransactionWithRetry(
 				console.error(err)
 			}
 		}
-		const sendRequests = connections.map((c) => c.sendRawTransaction(trx, options));
 		if (!signature) {
+			const sendRequests = connections.map((c) => c.sendRawTransaction(trx, options));
 			try {
 				signature = await Promise.any(sendRequests);
 			} catch (err) {


### PR DESCRIPTION
I think the current logic could cause the same transaction to be resubmitted a number of times since the has-signature case only bails when there is an error or the transaction is confirmed. 

This change moves the attempt to send transactions into the case where no signature has yet been set. 