### PR TITLE
Add etaSeconds to Quote type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -56,6 +56,7 @@ export type Quote = {
 	clientRelayerFeeSuccess: number | null;
 	clientRelayerFeeRefund: number | null;
 	eta: number;
+	etaSeconds: number;
 	clientEta: string;
 	fromToken: Token;
 	toToken: Token;


### PR DESCRIPTION
I noticed this is present in API response but not in this type :)

<img width="469" alt="image" src="https://github.com/user-attachments/assets/687fa7d7-fe6c-4282-8eed-651220cfe626">
