### PR TITLE
Surface `data` property from error response

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -125,6 +125,7 @@ export async function fetchQuote(params: QuoteParams, quoteOptions: QuoteOptions
 		throw {
 			code: result?.code || 0,
 			message: result?.msg || result?.message || 'Route not found',
+			data: result?.data,
 		} as QuoteError
 	}
 	if (!checkSdkVersionSupport(result.minimumSdkVersion)) {


### PR DESCRIPTION
Mayan quote API sometimes returns raw token amount as `data.minAmountIn`, but the `swap-sdk` doesn't include this in the value it throws. This change just includes it so we can make use of it downstream.

```
{
    "code": "AMOUNT_TOO_SMALL",
    "msg": "Amount too small (min ~0.0013 ETH)",
    "data": {
        "minAmountIn": 0.0013
    }
}
```