### PR TITLE
docs: fix typo in WalletConnect integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ async (tx: Transaction) => {
 );
 ```
 
-For swaps from EVM you can use `useWalletConnectModal` hook from  [WalletConnet](https://github.com/WalletConnect/modal-react-native) to get the provider and pass it to `swapFromEvm` function as the `signer`:
+For swaps from EVM you can use `useWalletConnectModal` hook from  [WalletConnect](https://github.com/WalletConnect/modal-react-native) to get the provider and pass it to `swapFromEvm` function as the `signer`:
 
 ```javascript
 import {useWalletConnectModal} from '@walletconnect/modal-react-native';


### PR DESCRIPTION
<img width="868" alt="Снимок экрана 2025-04-20 в 19 37 57" src="https://github.com/user-attachments/assets/652bd54b-5004-4300-9df0-ed5712766167" />

noticed a typo where "WalletConnet" was used instead of "WalletConnect".
Just corrected it to avoid confusion.