### PR TITLE
fix: Add base unit fields for minAmountOut and minReceived

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -83,7 +83,9 @@ export type Quote = {
 	expectedAmountOut: number;
 	priceImpact?: number | null;
 	minAmountOut: number;
+	minAmountOutBaseUnits: string;
 	minReceived: number;
+	minReceivedBaseUnits: string;
 	gasDrop: number;
 	price: number;
 	swapRelayerFee: number;


### PR DESCRIPTION
`minAmountOutBaseUnits` and `minReceivedBaseUnits` are missing from the quote type, while they are returned by the api response.

Example:
```https://price-api.mayan.finance/v3/quote?wormhole=true&swift=true&mctp=true&shuttle=false&fastMctp=true&gasless=false&onlyDirect=false&solanaProgram=FC4eXxkyrMPTjiYUpp4EAnkmwMbQyZ6NDCh1kfLn6vsf&forwarderAddress=0x337685fdaB40D39bd02028545a4FfA7D287cC3E2&amountIn64=50000000000&fromToken=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913&fromChain=base&toToken=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48&toChain=ethereum&slippageBps=10&sdkVersion=12_1_0```

<img width="317" height="176" alt="image" src="https://github.com/user-attachments/assets/f3a75fd6-3029-456c-9bdc-7d7193117a95" />
