### PR TITLE
Migrate Sui integration from @mysten/sui v1 SuiClient to the v2 SuiGr…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "14.3.0",
       "license": "MIT",
       "dependencies": {
-        "@mysten/sui": "^1.34.0",
+        "@mysten/sui": "^2.17.0",
         "@noble/hashes": "1.8.0",
         "@solana/buffer-layout": "^4 || ^3",
         "@solana/web3.js": "^1.87.6",
@@ -25,9 +25,10 @@
       }
     },
     "node_modules/@0no-co/graphql.web": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.0.12.tgz",
-      "integrity": "sha512-BTDjjsV/zSPy5fqItwm+KWUfh9CSe9tTtR6rCB72ddtkAxdcHbi4Ir4r/L1Et4lyxmL+i7Rb3m9sjLLi9tYrzA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphql.web/-/graphql.web-1.2.0.tgz",
+      "integrity": "sha512-/1iHy9TTr63gE1YcR5idjx8UREz1s0kFhydf3bBLCXyqjhkIc6igAzTOx3zPifCwFR87tsh/4Pa9cNts6d2otw==",
+      "license": "MIT",
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
       },
@@ -35,6 +36,20 @@
         "graphql": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@0no-co/graphqlsp": {
+      "version": "1.15.4",
+      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.15.4.tgz",
+      "integrity": "sha512-Nt1DVHcZ08lKRKwhiU0amXH77fSdrO6DzyjLE0DkCxfbM/N1SAs32d76y1xtCzM5H9eT0iDS7SdksgRXWJu05g==",
+      "license": "MIT",
+      "dependencies": {
+        "@gql.tada/internal": "^1.0.0",
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+        "typescript": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -405,6 +420,45 @@
         "node": ">=12"
       }
     },
+    "node_modules/@gql.tada/cli-utils": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.7.3.tgz",
+      "integrity": "sha512-3iQY5E/jvv3Lnh6D1Mh7zr+Bb9C/TGk1DHkm+lbIjQBnZAu2m+BcTcr1e3spUt6Aa6HG/xAN2XxpbWw9oZALEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphqlsp": "^1.12.13",
+        "@gql.tada/internal": "1.0.9",
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+      },
+      "peerDependencies": {
+        "@0no-co/graphqlsp": "^1.12.13",
+        "@gql.tada/svelte-support": "1.0.2",
+        "@gql.tada/vue-support": "1.0.2",
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+        "typescript": "^5.0.0 || ^6.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@gql.tada/svelte-support": {
+          "optional": true
+        },
+        "@gql.tada/vue-support": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@gql.tada/internal": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.9.tgz",
+      "integrity": "sha512-Bp8yi+kLrzIJ3l5Dfxhz48H4OCH2LCX+pShaPcJgh+oiBt6clrjUKDYNDD3Z78aDQ3+Tyrxe4dd0MfLgpSLPPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.5"
+      },
+      "peerDependencies": {
+        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
@@ -479,110 +533,75 @@
       }
     },
     "node_modules/@mysten/bcs": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-1.6.3.tgz",
-      "integrity": "sha512-QQ6u0U7a4+/o6rZ9tALTeGYMdf6V5z/HkRI/mhD5/fSr80DJoGzOWpFszcN/fhJpKb36vBaSQUMpS7yNQ10xBQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@mysten/bcs/-/bcs-2.0.5.tgz",
+      "integrity": "sha512-Dop9Xq36DPLlsmIDQZvUg4uJeBBxIGirgp2OXGaEff+mtLKFBoW2HnE3aSTSSpiMQH9XRhjwtiM16zFJhFqz0Q==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@mysten/utils": "0.1.0",
-        "@scure/base": "^1.2.6"
+        "@mysten/utils": "^0.3.3",
+        "@scure/base": "^2.0.0"
       }
     },
     "node_modules/@mysten/sui": {
-      "version": "1.34.0",
-      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-1.34.0.tgz",
-      "integrity": "sha512-Btf2Tq5VPXqABOXqtw9hV13DskepggP7MpeGb7OnRNF2grh1nHyWj9J0Y2UmkhZUEdTWpnVRnl/ufIZ6VmU1kg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@mysten/sui/-/sui-2.17.0.tgz",
+      "integrity": "sha512-TrS1BCPm4V6rC69MBejmcqnKIyJ5t1iksax4XA9jWarZxAAp9LMmdxEBebejyDT/yAJxYIf3fNm5WBkHE2qnIw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@mysten/bcs": "1.6.3",
-        "@mysten/utils": "0.1.0",
-        "@noble/curves": "^1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/base": "^1.2.6",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "gql.tada": "^1.8.2",
-        "graphql": "^16.11.0",
-        "poseidon-lite": "^0.2.0",
-        "valibot": "^0.36.0"
+        "@mysten/bcs": "^2.0.5",
+        "@mysten/utils": "^0.3.3",
+        "@noble/curves": "^2.0.1",
+        "@noble/hashes": "^2.0.1",
+        "@protobuf-ts/grpcweb-transport": "^2.11.1",
+        "@protobuf-ts/runtime": "^2.11.1",
+        "@protobuf-ts/runtime-rpc": "^2.11.1",
+        "@scure/base": "^2.0.0",
+        "@scure/bip32": "^2.0.1",
+        "@scure/bip39": "^2.0.1",
+        "gql.tada": "^1.9.0",
+        "graphql": "^16.12.0",
+        "poseidon-lite": "0.2.1",
+        "valibot": "^1.2.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=22"
       }
     },
-    "node_modules/@mysten/sui/node_modules/@0no-co/graphqlsp": {
-      "version": "1.12.16",
-      "resolved": "https://registry.npmjs.org/@0no-co/graphqlsp/-/graphqlsp-1.12.16.tgz",
-      "integrity": "sha512-B5pyYVH93Etv7xjT6IfB7QtMBdaaC07yjbhN6v8H7KgFStMkPvi+oWYBTibMFRMY89qwc9H8YixXg8SXDVgYWw==",
+    "node_modules/@mysten/sui/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
       "dependencies": {
-        "@gql.tada/internal": "^1.0.0",
-        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+        "@noble/hashes": "2.2.0"
       },
-      "peerDependencies": {
-        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0"
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@mysten/sui/node_modules/@gql.tada/cli-utils": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@gql.tada/cli-utils/-/cli-utils-1.6.3.tgz",
-      "integrity": "sha512-jFFSY8OxYeBxdKi58UzeMXG1tdm4FVjXa8WHIi66Gzu9JWtCE6mqom3a8xkmSw+mVaybFW5EN2WXf1WztJVNyQ==",
-      "dependencies": {
-        "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/internal": "1.0.8",
-        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0"
+    "node_modules/@mysten/sui/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
       },
-      "peerDependencies": {
-        "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/svelte-support": "1.0.1",
-        "@gql.tada/vue-support": "1.0.1",
-        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@gql.tada/svelte-support": {
-          "optional": true
-        },
-        "@gql.tada/vue-support": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mysten/sui/node_modules/@gql.tada/internal": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@gql.tada/internal/-/internal-1.0.8.tgz",
-      "integrity": "sha512-XYdxJhtHC5WtZfdDqtKjcQ4d7R1s0d1rnlSs3OcBEUbYiPoJJfZU7tWsVXuv047Z6msvmr4ompJ7eLSK5Km57g==",
-      "dependencies": {
-        "@0no-co/graphql.web": "^1.0.5"
-      },
-      "peerDependencies": {
-        "graphql": "^15.5.0 || ^16.0.0 || ^17.0.0",
-        "typescript": "^5.0.0"
-      }
-    },
-    "node_modules/@mysten/sui/node_modules/gql.tada": {
-      "version": "1.8.10",
-      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.8.10.tgz",
-      "integrity": "sha512-FrvSxgz838FYVPgZHGOSgbpOjhR+yq44rCzww3oOPJYi0OvBJjAgCiP6LEokZIYND2fUTXzQAyLgcvgw1yNP5A==",
-      "dependencies": {
-        "@0no-co/graphql.web": "^1.0.5",
-        "@0no-co/graphqlsp": "^1.12.13",
-        "@gql.tada/cli-utils": "1.6.3",
-        "@gql.tada/internal": "1.0.8"
-      },
-      "bin": {
-        "gql-tada": "bin/cli.js",
-        "gql.tada": "bin/cli.js"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@mysten/utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.1.0.tgz",
-      "integrity": "sha512-nFxqArh4cr629elLsIk7UZmx5dFVshblwrfwaG7Dm2L/ii2C65bhK5tdTs6UiC3K0tCr8q8svrgzXyF9L0CN/A==",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.3.3.tgz",
+      "integrity": "sha512-gVHn5toh24eXXLEyBknwwM2F/tbDgqPX0yj77KtHjuoYUallcQ9vSwGfGsAy39IcTB259Yprt/ZOEwdup+zrpA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@scure/base": "^1.2.6"
+        "@scure/base": "^2.0.0"
       }
     },
     "node_modules/@noble/curves": {
@@ -656,34 +675,101 @@
         "node": ">=14"
       }
     },
+    "node_modules/@protobuf-ts/grpcweb-transport": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/grpcweb-transport/-/grpcweb-transport-2.11.1.tgz",
+      "integrity": "sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.11.1",
+        "@protobuf-ts/runtime-rpc": "^2.11.1"
+      }
+    },
+    "node_modules/@protobuf-ts/runtime": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime/-/runtime-2.11.1.tgz",
+      "integrity": "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@protobuf-ts/runtime-rpc": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@protobuf-ts/runtime-rpc/-/runtime-rpc-2.11.1.tgz",
+      "integrity": "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@protobuf-ts/runtime": "^2.11.1"
+      }
+    },
     "node_modules/@scure/base": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
-      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.2.0.tgz",
+      "integrity": "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg==",
+      "license": "MIT",
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip32": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.7.0.tgz",
-      "integrity": "sha512-E4FFX/N3f4B80AKWp5dP6ow+flD1LQZo/w8UnLGYZO674jS6YnYeepycOOksv+vLPSpgN35wgKgy+ybfTb2SMw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-2.2.0.tgz",
+      "integrity": "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/curves": "~1.9.0",
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
+        "@noble/curves": "2.2.0",
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-2.2.0.tgz",
+      "integrity": "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "2.2.0"
+      },
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@scure/bip39": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
-      "integrity": "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-2.2.0.tgz",
+      "integrity": "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A==",
+      "license": "MIT",
       "dependencies": {
-        "@noble/hashes": "~1.8.0",
-        "@scure/base": "~1.2.5"
+        "@noble/hashes": "2.2.0",
+        "@scure/base": "2.2.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.2.0.tgz",
+      "integrity": "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -969,19 +1055,6 @@
         "ieee754": "^1.2.1"
       }
     },
-    "node_modules/bufferutil": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.8.tgz",
-      "integrity": "sha512-4T53u4PdgsXqKaIctwF8ifXlRTTmEPJ8iEPWFdGZvcf7sbwYo6FKFEX9eNNAnzFZ7EzJAQ3CJeOtCRA4rDp7Pw==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
-      }
-    },
     "node_modules/bundle-require": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/bundle-require/-/bundle-require-4.0.2.tgz",
@@ -1152,6 +1225,7 @@
       "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1423,10 +1497,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gql.tada": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/gql.tada/-/gql.tada-1.9.2.tgz",
+      "integrity": "sha512-QxRHVpxtrOVdYXz6oavq0lBM+Zdp0swapLGJcD4SLpXDcsD337BHDFrzqqjfkbepv0sSAiO0LGabu1kI5D5Gyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@0no-co/graphql.web": "^1.0.5",
+        "@0no-co/graphqlsp": "^1.12.13",
+        "@gql.tada/cli-utils": "1.7.3",
+        "@gql.tada/internal": "1.0.9"
+      },
+      "bin": {
+        "gql-tada": "bin/cli.js",
+        "gql.tada": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^6.0.0"
+      }
+    },
     "node_modules/graphql": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
-      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "version": "16.14.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.14.2.tgz",
+      "integrity": "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==",
+      "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -2432,25 +2527,13 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
-      }
-    },
-    "node_modules/utf-8-validate": {
-      "version": "5.0.10",
-      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.10.tgz",
-      "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
-      "hasInstallScript": true,
-      "optional": true,
-      "dependencies": {
-        "node-gyp-build": "^4.3.0"
-      },
-      "engines": {
-        "node": ">=6.14.2"
       }
     },
     "node_modules/uuid": {
@@ -2462,9 +2545,18 @@
       }
     },
     "node_modules/valibot": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/valibot/-/valibot-0.36.0.tgz",
-      "integrity": "sha512-CjF1XN4sUce8sBK9TixrDqFM7RwNkuXdJu174/AwmQUB62QbCQADg5lLe8ldBalFgtj1uKj+pKwDJiNo4Mn+eQ=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.4.1.tgz",
+      "integrity": "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -2590,6 +2682,7 @@
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "author": "Jiri",
   "dependencies": {
-    "@mysten/sui": "^1.34.0",
+    "@mysten/sui": "^2.17.0",
     "@noble/hashes": "1.8.0",
     "@solana/buffer-layout": "^4 || ^3",
     "@solana/web3.js": "^1.87.6",

--- a/src/sui/suiMctp.ts
+++ b/src/sui/suiMctp.ts
@@ -1,6 +1,6 @@
 import { Transaction, TransactionResult, TransactionObjectArgument } from '@mysten/sui/transactions';
 import { SUI_TYPE_ARG, SUI_CLOCK_OBJECT_ID } from '@mysten/sui/utils';
-import { SuiClient } from '@mysten/sui/client';
+import type { SuiGrpcClient } from '@mysten/sui/grpc';
 import {
 	Quote,
 	SuiFunctionParameter,
@@ -35,7 +35,7 @@ export async function createMctpFromSuiMoveCalls(
 	destinationAddress: string,
 	referrerAddress: string | null | undefined,
 	payload: Uint8Array | Buffer | null | undefined,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	options?: ComposableSuiMoveCallsOptions
 ): Promise<Transaction> {
 	if (!quote.fromToken.verifiedAddress) {
@@ -185,7 +185,7 @@ export async function addBridgeWithFeeMoveCalls(
 	destinationAddress: string,
 	mctpPackageId: string,
 	payload: Uint8Array | Buffer | null | undefined,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	options?: ComposableSuiMoveCallsOptions
 ): Promise<Transaction> {
 	return addBridgeWithFeeMoveCalls2({
@@ -213,7 +213,7 @@ export async function addBridgeLockedFeeMoveCalls(
 	swapperAddress: string,
 	destinationAddress: string,
 	mctpPackageId: string,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	options?: ComposableSuiMoveCallsOptions
 ): Promise<Transaction> {
 	const destChainId = getWormholeChainIdByName(quote.toChain);
@@ -320,7 +320,7 @@ export async function addInitOrderMoveCalls(
 	referrerAddress: string | null | undefined,
 	mctpPackageId: string,
 	feeManagerPackageId: string,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	options?: ComposableSuiMoveCallsOptions
 ): Promise<Transaction> {
 	const destChainId = getWormholeChainIdByName(quote.toChain);
@@ -488,7 +488,7 @@ export async function addInitOrderMoveCalls(
 async function addPublishWormholeMessage(
 	tx: Transaction,
 	messageTicket: SuiFunctionNestedResult,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	bridgeFee: bigint,
 	feePayer: string,
 	suiCoin?: SuiFunctionParameter | null
@@ -558,7 +558,7 @@ export async function addBridgeWithFeeMoveCalls2(params:{
 	mctpInputTreasury: string,
 	bridgeFee: number,
 	payload: Uint8Array | Buffer | null | undefined,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	options?: ComposableSuiMoveCallsOptions
 }): Promise<Transaction> {
 	const {

--- a/src/sui/suiSwap.ts
+++ b/src/sui/suiSwap.ts
@@ -3,7 +3,7 @@ import {
 	ReferrerAddresses,
 	ComposableSuiMoveCallsOptions,
 } from '../types';
-import { SuiClient } from '@mysten/sui/client';
+import type { SuiGrpcClient } from '@mysten/sui/grpc';
 import { Transaction } from '@mysten/sui/transactions';
 import { getQuoteSuitableReferrerAddress } from '../utils';
 import { createMctpFromSuiMoveCalls } from './suiMctp';
@@ -16,7 +16,7 @@ export async function createSwapFromSuiMoveCalls(
 	destinationAddress: string,
 	referrerAddresses: ReferrerAddresses | null | undefined,
 	payload: Uint8Array | Buffer | null | undefined,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	options?: ComposableSuiMoveCallsOptions
 ): Promise<Transaction> {
 	const referrerAddress = getQuoteSuitableReferrerAddress(

--- a/src/sui/suiSwift.ts
+++ b/src/sui/suiSwift.ts
@@ -1,6 +1,6 @@
 import {Transaction, TransactionResult, TransactionObjectArgument} from '@mysten/sui/transactions';
 import {SUI_TYPE_ARG, SUI_CLOCK_OBJECT_ID} from '@mysten/sui/utils';
-import {SuiClient} from '@mysten/sui/client';
+import type {SuiGrpcClient} from '@mysten/sui/grpc';
 import {
 	Quote,
 	SuiFunctionParameter,
@@ -30,7 +30,7 @@ export async function createSwiftFromSuiMoveCalls(
 	destinationAddress: string,
 	referrerAddress: string | null | undefined,
 	payload: Uint8Array | Buffer | null | undefined,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	options?: ComposableSuiMoveCallsOptions & { randomKey?: Uint8Array }
 ): Promise<Transaction> {
 	if (!quote.fromToken.verifiedAddress || !quote.swiftVerifiedInputAddress) {
@@ -122,7 +122,7 @@ export async function addInitSwiftOrderMoveCalls(
 	swiftPackageId: string,
 	feeManagerPackageId: string,
 	payload: Uint8Array | Buffer | null | undefined,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	options?: ComposableSuiMoveCallsOptions & { randomKey?: Uint8Array }
 ): Promise<Transaction> {
 	const destChainId = getWormholeChainIdByName(quote.toChain);

--- a/src/sui/utils.ts
+++ b/src/sui/utils.ts
@@ -1,12 +1,10 @@
-import {
-	SuiClient,
-	SuiMoveFunctionArgType,
-	CoinStruct,
-	PaginatedCoins,
-	SuiObjectResponse,
-} from '@mysten/sui/client';
+import type { SuiGrpcClient } from '@mysten/sui/grpc';
 import { SuiFunctionNestedResult, SuiFunctionParameter } from '../types';
 import { Transaction, TransactionResult } from '@mysten/sui/transactions';
+
+// Minimal coin shape used by fetchAllCoins/resolveInputCoin (subset of the v1
+// CoinStruct). v2 `listCoins` returns `objectId` and `balance` (as a string).
+type SuiCoin = { coinObjectId: string; balance: string; coinType: string };
 
 /**
  * assertArgumentIsImmutable
@@ -19,7 +17,7 @@ import { Transaction, TransactionResult } from '@mysten/sui/transactions';
  *    - module: The name of the Move module.
  *    - function: The name of the Move function to validate.
  *    - argumentIndex: The index of the argument to check for immutability.
- * @param suiClient - An instance of `SuiClient` used to interact with the Sui blockchain.
+ * @param suiClient - An instance of `SuiGrpcClient` used to interact with the Sui blockchain.
  *
  * @throws Will throw an error if:
  *    - The argument types cannot be retrieved from the Sui client.
@@ -34,33 +32,34 @@ export async function assertArgumentIsImmutable(
 		function: string;
 		argumentIndex: number;
 	},
-	suiClient: SuiClient
+	suiClient: SuiGrpcClient
 ): Promise<void> {
-	let argTypes: SuiMoveFunctionArgType[];
+	let parameters: Awaited<
+		ReturnType<SuiGrpcClient['getMoveFunction']>
+	>['function']['parameters'];
 	try {
-		argTypes = await suiClient.getMoveFunctionArgTypes({
-			package: params.package,
-			module: params.module,
-			function: params.function,
+		const { function: fn } = await suiClient.getMoveFunction({
+			packageId: params.package,
+			moduleName: params.module,
+			name: params.function,
 		});
+		parameters = fn.parameters;
 	} catch (error) {
 		throw new Error(
 			`Failed to fetch ${params.package}::${params.module}::${params.function} ArgTypes`
 		);
 	}
-	if (argTypes) {
-		if (
-			argTypes[params.argumentIndex] !== 'Pure' &&
-			//@ts-ignore
-			argTypes[params.argumentIndex]?.Object !== 'ByImmutableReference'
-		) {
-			throw new Error(
-				`Argument ${params.argumentIndex} of ${params.module}::${params.function} is not immutable`
-			);
-		}
-	} else {
+	// v1 `getMoveFunctionArgTypes` accepted only `Pure` (a by-value primitive) or
+	// `Object: ByImmutableReference`. v2 `getMoveFunction` returns each parameter as
+	// `{ reference: 'immutable' | 'mutable' | null, body }`, so map equivalently:
+	//   immutable ref  -> reference === 'immutable'                  (was ByImmutableReference)
+	//   pure by-value  -> reference == null && body is not a datatype (was 'Pure')
+	const param = parameters?.[params.argumentIndex];
+	const isImmutableRef = param?.reference === 'immutable';
+	const isPure = param?.reference == null && param?.body?.$kind !== 'datatype';
+	if (!param || (!isImmutableRef && !isPure)) {
 		throw new Error(
-			`Failed to fetch package::${params.module}::${params.function} ArgTypes`
+			`Argument ${params.argumentIndex} of ${params.module}::${params.function} is not immutable`
 		);
 	}
 }
@@ -80,7 +79,7 @@ export async function assertArgumentIsImmutable(
  *    - coinType: The type of coin to filter for during retrieval.
  *    - coinAmount: The target coin amount to reach.
  *
- * @param suiClient - An instance of `SuiClient` used to interact with the Sui blockchain.
+ * @param suiClient - An instance of `SuiGrpcClient` used to interact with the Sui blockchain.
  *
  * @returns A Promise that resolves to an object containing:
  *    - coins: An array of CoinStruct objects representing the retrieved coins.
@@ -92,24 +91,28 @@ export async function fetchAllCoins(
 		coinType: string;
 		coinAmount: bigint;
 	},
-	suiClient: SuiClient
+	suiClient: SuiGrpcClient
 ): Promise<{
-	coins: CoinStruct[];
+	coins: SuiCoin[];
 	sum: bigint;
 }> {
-	let allCoinData: CoinStruct[] = [];
+	let allCoinData: SuiCoin[] = [];
 	let currentSum = BigInt(0);
-	let cursor: string | undefined = undefined;
+	let cursor: string | null = null;
 	do {
-		const paginatedCoins: PaginatedCoins = await suiClient.getCoins({
-			...inputs,
+		const paginatedCoins = await suiClient.listCoins({
 			owner: inputs.walletAddress,
+			coinType: inputs.coinType,
 			cursor,
 		});
 
-		const coinData = paginatedCoins.data.filter(
-			(data) => BigInt(data.balance) > BigInt(0)
-		);
+		const coinData: SuiCoin[] = paginatedCoins.objects
+			.map((c) => ({
+				coinObjectId: c.objectId,
+				balance: c.balance ?? '0',
+				coinType: inputs.coinType,
+			}))
+			.filter((coin) => BigInt(coin.balance) > BigInt(0));
 		allCoinData = [...allCoinData, ...coinData];
 
 		coinData.forEach((coin) => {
@@ -117,9 +120,9 @@ export async function fetchAllCoins(
 		});
 
 		if (
-			paginatedCoins.data.length === 0 ||
+			paginatedCoins.objects.length === 0 ||
 			!paginatedCoins.hasNextPage ||
-			!paginatedCoins.nextCursor ||
+			!paginatedCoins.cursor ||
 			currentSum >= inputs.coinAmount
 		)
 			return {
@@ -129,7 +132,7 @@ export async function fetchAllCoins(
 				sum: currentSum,
 			};
 
-		cursor = paginatedCoins.nextCursor;
+		cursor = paginatedCoins.cursor;
 	} while (true);
 }
 
@@ -143,29 +146,28 @@ export async function fetchAllCoins(
  * - Upgrades to Mayan packages require multiple signatures to perform, enhancing governance and security.
  *
  * @param {string} stateObjectId - The ID of the shared state object containing the latest package ID.
- * @param {SuiClient} suiClient - An instance of the SuiClient used to interact with the Sui blockchain.
+ * @param {SuiGrpcClient} suiClient - An instance of the SuiGrpcClient used to interact with the Sui blockchain.
  * @returns {Promise<string>} - A promise that resolves to the latest Mayan Sui package ID.
  * @throws {Error} - Throws an error if the state object cannot be fetched or if the `latest_package_id` field is not found.
  */
 export async function fetchMayanSuiPackageId(
 	stateObjectId: string,
-	suiClient: SuiClient
+	suiClient: SuiGrpcClient
 ): Promise<string> {
-	let object: SuiObjectResponse;
+	let json: Record<string, any> | null;
 	try {
-		object = await suiClient.getObject({
-			id: stateObjectId,
-			options: {
-				showContent: true,
-			},
+		// v2 gRPC `getObject({ include: { json: true } })` returns a flat Move-struct
+		// map on `object.json` (no v1 `data.content.fields` wrapper).
+		const { object } = await suiClient.getObject({
+			objectId: stateObjectId,
+			include: { json: true },
 		});
+		json = (object?.json ?? null) as Record<string, any> | null;
 	} catch (err) {
 		throw new Error(`Failed to fetch Mayan Sui package ID: \n\n ${err}`);
 	}
-	// @ts-ignore
-	if (object.data?.content?.fields?.latest_package_id) {
-		// @ts-ignore
-		return object.data.content.fields.latest_package_id;
+	if (json?.latest_package_id) {
+		return json.latest_package_id as string;
 	}
 	throw new Error('latest_package_id not found in Mayan Sui state object');
 }
@@ -174,7 +176,7 @@ export async function resolveInputCoin(
 	amount: bigint,
 	owner: string,
 	coinType: string,
-	suiClient: SuiClient,
+	suiClient: SuiGrpcClient,
 	tx: Transaction,
 	preparedCoin?: SuiFunctionParameter | null
 ) {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
 		"skipLibCheck": true,
 		"forceConsistentCasingInFileNames": true,
 		"sourceMap": false,
-		"moduleResolution": "node",
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"baseUrl": ".",
 		"declaration": true,
 		"outDir": "./lib"

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -13,6 +13,9 @@ export default defineConfig((options) => {
 		clean: false,
 		outDir: 'dist',
 		dts: options.minify,
+		// @mysten/sui v2 is ESM-only; bundle it (and its ESM-only transitive deps)
+		// into the output so the CJS build can consume it via require().
+		noExternal: ['@mysten/sui'],
 		format,
 		outExtension: options.minify ? ({ format }) => {
 			return {


### PR DESCRIPTION
…pcClient

Sui is deprecating JSON-RPC in favor of gRPC by July 2026, so move the Sui swap paths onto the v2 SuiGrpcClient. Ports the three RPC calls: getCoins->listCoins, getObject (now flat-json), and getMoveFunctionArgTypes->getMoveFunction (mapping v1 Pure/ByImmutableReference to v2 parameter.reference). Bumps @mysten/sui to ^2.17.0, switches tsconfig moduleResolution to bundler, and bundles the now ESM-only @mysten/sui into the CJS build via tsup noExternal.